### PR TITLE
Better fog patch

### DIFF
--- a/DoW Mod Manager/FogRemover.cs
+++ b/DoW Mod Manager/FogRemover.cs
@@ -16,11 +16,12 @@ namespace SSNoFog
 {
     public static class FogRemover
     {
-        private static readonly byte[] nope6             = new byte[6] { 144, 144, 144, 144, 144, 144 };
+        private static readonly byte[] getZero           = new byte[6] { 217, 238,  15,  31,  64,   0 };
+        private static readonly byte[] setNothing        = new byte[6] { 221, 216,  15,  31,  64,   0 };
         private static readonly byte[] float512          = new byte[4] {   0,   0,   0,  68 };
-        private static readonly byte[] codeF512          = new byte[4] {   0,   0, 192,  66 };
-        private static readonly byte[] jmpFog            = new byte[6] { 217, 129,  96,  12,   0,   0 };
-        private static readonly byte[] jmpMapSkyDistance = new byte[6] { 217, 155, 112,  12,   0,   0 };
+        private static readonly byte[] float96           = new byte[4] {   0,   0, 192,  66 };
+        private static readonly byte[] getFog            = new byte[6] { 217, 129,  96,  12,   0,   0 };
+        private static readonly byte[] setMapSkyDistance = new byte[6] { 217, 155, 112,  12,   0,   0 };
 
         private const int PAGE_EXECUTE_READWRITE = 0x40;
 
@@ -58,9 +59,9 @@ namespace SSNoFog
             IntPtr pHandle = OpenProcess(56, false, process.Id);
             try
             {
-                CheckToggleMemory(fogAddress, jmpFog, nope6, pHandle);
-                CheckToggleMemory(float512Address, codeF512, float512, pHandle);
-                CheckToggleMemory(mapSkyDistanceAddress, jmpMapSkyDistance, nope6, pHandle);
+                CheckToggleMemory(fogAddress, getFog, getZero, pHandle);
+                CheckToggleMemory(float512Address, float96, float512, pHandle);
+                CheckToggleMemory(mapSkyDistanceAddress, setMapSkyDistance, setNothing, pHandle);
             }
             finally
             {


### PR DESCRIPTION
The previous fog patch has some issues, misaligning the x87 stack mainly, and some poor naming

jmpFog -> getFog:
`fld DWORD PTR [ecx+0xc60]`
This is not a jmp instruction but a fld instruction, it loads the fog end distance onto the x87 stack.
The previous solution of removing the instruction entirely, no longer loads something onto the stack, misaligning it and using whatever value happened to exist there before.
This has been replaced with the `fldz` instruction, which always loads 0 onto the stack, and mimics how the fog_toggle command works (sets end distance to 0).

codeF512 -> float96:
`0, 0, 192, 66` isn't code and is just the bytes for 96.0
For the below explanation: float512Address is the address for default sky distance, which the fog patch changes from 96 to 512, allowing you to zoom out more without the the ground unloading.

jmpMapSkyDistance -> setMapSkyDistance:
`fstp DWORD PTR [ebx+0xc70]`
This is also not a jmp instruction but a fstp instruction, related to how far you can zoom out before the game stops drawing parts of the ground. The game at this instruction is replacing the default sky distance value (now 512) with a more specific value, but we always want the large default.
The previous solution of removing the instruction entirely, doesn't remove a value from the stack anymore, misaligning it.
This was replaced with `fstp st(0)`, which prevents the game from changing the default value, but also removes the new value from the stack.